### PR TITLE
Upgrade hubot-slack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,14 +5,14 @@
   "requires": true,
   "dependencies": {
     "@slack/client": {
-      "version": "3.16.1-sec",
-      "resolved": "https://registry.npmjs.org/@slack/client/-/client-3.16.1-sec.tgz",
-      "integrity": "sha512-M1CGVup9P73XvKDgX9Dc/P0N/U1dBjYdWMn4w4QELWuX/eIMt5XyEuZNU49trdm87YrZO6zcc9e9xCHvYGgEBQ==",
+      "version": "3.16.1-sec.2",
+      "resolved": "https://registry.npmjs.org/@slack/client/-/client-3.16.1-sec.2.tgz",
+      "integrity": "sha512-FAERJJAurczrvgShW+9V95NdVYgf8FdIexUqfBgNuToRrLRDRcWNf0nGyfKAvl2RH1ncppzJp3iXgMNJFnJXhQ==",
       "requires": {
         "async": "^1.5.0",
         "bluebird": "^3.3.3",
         "eventemitter3": "^1.1.1",
-        "https-proxy-agent": "^1.0.0",
+        "https-proxy-agent": "^2.2.0",
         "inherits": "^2.0.1",
         "lodash": "^4.13.1",
         "pkginfo": "^0.4.0",
@@ -25,7 +25,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         }
       }
@@ -45,12 +45,11 @@
       }
     },
     "agent-base": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
-      "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
       "requires": {
-        "extend": "~3.0.0",
-        "semver": "~5.0.1"
+        "es6-promisify": "^5.0.0"
       }
     },
     "ajv": {
@@ -127,9 +126,9 @@
       }
     },
     "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
+      "integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg=="
     },
     "body-parser": {
       "version": "1.18.2",
@@ -412,6 +411,19 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
       "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
     },
+    "es6-promise": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
+      "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg=="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "requires": {
+        "es6-promise": "^4.0.3"
+      }
+    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -677,13 +689,27 @@
       }
     },
     "https-proxy-agent": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
-      "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
       "requires": {
-        "agent-base": "2",
-        "debug": "2",
-        "extend": "3"
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
       }
     },
     "hubot": {
@@ -853,11 +879,11 @@
       "integrity": "sha1-T7yeFhlTv3kB/cNuKnAsExA/FrI="
     },
     "hubot-slack": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/hubot-slack/-/hubot-slack-4.5.4.tgz",
-      "integrity": "sha512-gKMvAlBoP6I5u2mCEYlPzdNRwCMefbBBKvNAQy4AR8WS7I/Tlg+f1dg1Z3VYz4/lVV3nkP4RXXGvGExvUICUug==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/hubot-slack/-/hubot-slack-4.5.5.tgz",
+      "integrity": "sha512-nlURcILQG1tdE3bA2BUiAvFpmMe/wwoaJVFT9Kzet2BC5pLZoZDdXZOLYAQBfUJUq/2mkLJfsuykvna3PezHUQ==",
       "requires": {
-        "@slack/client": "3.16.1-sec",
+        "@slack/client": "3.16.1-sec.2",
         "bluebird": "^3.5.1",
         "lodash": "^4.17.10"
       }
@@ -1214,11 +1240,6 @@
       "resolved": "https://registry.npmjs.org/scoped-http-client/-/scoped-http-client-0.11.0.tgz",
       "integrity": "sha1-iH+oKoNg8V1jmlLlBOVjwVfSbXQ="
     },
-    "semver": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-      "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no="
-    },
     "send": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
@@ -1435,7 +1456,7 @@
       "dependencies": {
         "async": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.0.0.tgz",
           "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
         }
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "hubot-redis-brain": "1.0.0",
     "hubot-rules": "^1.0.0",
     "hubot-shipit": "^0.2.1",
-    "hubot-slack": "^4.5.4"
+    "hubot-slack": "^4.5.5"
   },
   "scripts": {
     "start": "bin/hubot --adapter slack --alias '!'",


### PR DESCRIPTION
This hubot-slack release finally addresses CVE-2018-3736 by upgrading @slack/client.